### PR TITLE
fix: Update render_all to respect render order

### DIFF
--- a/death_handlers.py
+++ b/death_handlers.py
@@ -1,6 +1,7 @@
 import tcod as libtcod
 
 from game_states import GameStates
+from render_functions import RenderOrder
 
 
 def kill_player(player):
@@ -19,5 +20,6 @@ def kill_monster(monster):
     monster.fighter = None
     monster.ai = None
     monster.name = f"remains of {monster.name}" 
+    monster.render_order = RenderOrder.CORPSE
 
     return death_message

--- a/engine.py
+++ b/engine.py
@@ -7,7 +7,7 @@ from fov_functions import initialize_fov, recompute_fov
 from game_states import GameStates
 from input_handlers import handle_keys
 from map_objects.game_map import GameMap
-from render_functions import clear_all, render_all
+from render_functions import clear_all, render_all, RenderOrder
 
 
 def main():
@@ -45,7 +45,7 @@ def main():
         hp=30, defense=2, power=5
     )  # define a fighter component for the player
     player = Entity(
-        0, 0, "@", libtcod.white, "Player", blocks=True, fighter=fighter_component
+        0, 0, "@", libtcod.white, "Player", blocks=True, render_order=RenderOrder.ACTOR, fighter=fighter_component
     )
     # World entity list
     entities = [player]

--- a/entity.py
+++ b/entity.py
@@ -2,6 +2,8 @@ import math
 
 import tcod as libtcod
 
+from render_functions import RenderOrder
+
 
 class Entity:
     """A generic class used to represent player, npcs, enemies
@@ -15,6 +17,7 @@ class Entity:
         color: object,
         name: str,
         blocks: bool = False,
+        render_order = RenderOrder.CORPSE,
         fighter: object = None,
         ai: object = None,
     ):
@@ -28,6 +31,7 @@ class Entity:
             name {str} -- Name of the entity
         Keyword Arguments:
             blocks {bool} -- Block behaviour flag (default: {False})
+            render_order {Enum} -- Controls rendering priority (default: {RenderOrder.CORPSE})
             fighter {object} -- fighting component (default: {None})
             ai {object} -- AI component (default: {None})
         """
@@ -37,6 +41,7 @@ class Entity:
         self.color = color
         self.name = name
         self.blocks = blocks
+        self.render_order = render_order
         self.fighter = fighter
         self.ai = ai
 

--- a/map_objects/game_map.py
+++ b/map_objects/game_map.py
@@ -7,6 +7,7 @@ from components.fighter import Fighter
 from entity import Entity
 from map_objects.tile import Tile
 from map_objects.room import Room
+from render_functions import RenderOrder
 
 
 class GameMap:
@@ -160,6 +161,7 @@ class GameMap:
                         libtcod.desaturated_green,
                         "Orc",
                         blocks=True,
+                        render_order=RenderOrder.ACTOR,
                         fighter=fighter_component,
                         ai=ai_component,
                     )
@@ -173,6 +175,7 @@ class GameMap:
                         libtcod.darker_green,
                         "Troll",
                         blocks=True,
+                        render_order=RenderOrder.ACTOR,
                         fighter=fighter_component,
                         ai=ai_component,
                     )

--- a/render_functions.py
+++ b/render_functions.py
@@ -1,4 +1,12 @@
+from enum import Enum, auto
+
 import tcod as libtcod
+
+
+class RenderOrder(Enum):
+    CORPSE = 1
+    ITEM = 2
+    ACTOR = 3
 
 
 def render_all(
@@ -52,8 +60,9 @@ def render_all(
                             con, x, y, colors.get("dark_ground"), libtcod.BKGND_SET
                         )
 
-    # Draw all entities in the list
-    for entity in entities:
+    # Draw all entities in the list from lowest to highest priority
+    entities_in_render_order = sorted(entities, key=lambda x: x.render_order.value)
+    for entity in entities_in_render_order:
         draw_entity(con, entity, fov_map)
 
     libtcod.console_set_default_foreground(con, libtcod.white)


### PR DESCRIPTION
Fixed a bug that would make corpses render above the player or active entities.